### PR TITLE
fix: use a cargo valid feature (# TODO 'downgrade' to a more specific)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ rayon = "1.7.0"
 reqwest = { version = "0.11.18", features = ["json", "blocking", "rustls-tls"]}
 serde = { version = "1.0.183", features = ["derive"] }
 thiserror = "1.0.44"
-tokio = "1.32.0", features=["main"]
+tokio = {version = "1.32.0", features=["full"] }
 trust-dns-resolver = "0.22.0"


### PR DESCRIPTION
fixes:
```
error: failed to parse manifest at `/Users/romulo.collopy/Projects/Contributions/dedscan/Cargo.toml`

Caused by:
  could not parse input as TOML

Caused by:
  TOML parse error at line 14, column 17
     |
  14 | tokio = "1.32.0", features=["main"]
     |                 ^
  expected newline, `#`
```

and 

```
error: failed to select a version for `tokio`.
    ... required by package `dedscan v0.1.0 (/Users/romulo.collopy/Projects/Contributions/dedscan)`
versions that meet the requirements `^1.32.0` (locked to 1.32.0) are: 1.32.0

the package `dedscan` depends on `tokio`, with features: `main` but `tokio` does not have these features.
```